### PR TITLE
Switch GitHub Actions deployment to Docker image

### DIFF
--- a/.github/workflows/main_bridge-delay-app.yml
+++ b/.github/workflows/main_bridge-delay-app.yml
@@ -2,7 +2,7 @@
 # More GitHub Actions for Azure: https://github.com/Azure/actions
 # More info on Python, GitHub Actions, and Azure App Service: https://aka.ms/python-webapps-actions
 
-name: Build and deploy Python app to Azure Web App - bridge-delay-app
+name: Build and deploy container to Azure Web App - bridge-delay-app
 
 on:
   push:
@@ -19,31 +19,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python version
-        uses: actions/setup-python@v5
+      - name: Log in to container registry
+        uses: docker/login-action@v3
         with:
-          python-version: '3.11'
+          registry: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Create and start virtual environment
+      - name: Build and push Docker image
         run: |
-          python -m venv venv
-          source venv/bin/activate
-      
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-        
-      # Optional: Add step to run tests here (PyTest, Django test suites, etc.)
-
-      - name: Zip artifact for deployment
-        run: zip release.zip ./* -r
-
-      - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-app
-          path: |
-            release.zip
-            !venv/
+          docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/bridge-delay-app:${{ github.sha }} -f dockerfile .
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/bridge-delay-app:${{ github.sha }}
 
   deploy:
     runs-on: ubuntu-latest
@@ -54,15 +40,6 @@ jobs:
       contents: read #This is required for actions/checkout
 
     steps:
-      - name: Download artifact from build job
-        uses: actions/download-artifact@v4
-        with:
-          name: python-app
-
-      - name: Unzip artifact for deployment
-        run: unzip release.zip
-
-      
       - name: Login to Azure
         uses: azure/login@v2
         with:
@@ -70,10 +47,11 @@ jobs:
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_290B337912884FBBBE4FE16062C5D5D8 }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_8438F652E74442D8A0478EB2E5D6168E }}
 
-      - name: 'Deploy to Azure Web App'
+      - name: 'Deploy container to Azure Web App'
         uses: azure/webapps-deploy@v3
         id: deploy-to-webapp
         with:
           app-name: 'bridge-delay-app'
           slot-name: 'Production'
+          images: ${{ secrets.REGISTRY_LOGIN_SERVER }}/bridge-delay-app:${{ github.sha }}
           


### PR DESCRIPTION
## Summary
- change workflow to build and push Docker image
- deploy Web App from the container image instead of zipped source

## Testing
- `python -m py_compile main.py webhook.py`

------
https://chatgpt.com/codex/tasks/task_e_6871b83eb5e08323b5f1baf1428da82a