### PR TITLE
feat: add background polling thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ The application expects the following variables to be defined:
 - `TWILIO_FROM_NUMBER` – The Twilio phone number that sends the alerts.
 - `TWILIO_TO_NUMBERS` – Comma-separated list of recipient numbers for the
   monitor when running without per-user settings.
+- `ENABLE_POLLING` – Set to `0` to disable the background polling thread
+  (defaults to enabled).
+- `POLL_INTERVAL` – Interval in seconds between delay checks. Defaults to
+  `300` seconds. Setting it to `0` also disables polling.
 
 ## Running locally
 

--- a/bridge_app.py
+++ b/bridge_app.py
@@ -21,6 +21,7 @@ import time
 import json
 import argparse
 import re
+import threading
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -38,6 +39,14 @@ ACCOUNT_SID  = os.getenv("TWILIO_ACCOUNT_SID")
 AUTH_TOKEN   = os.getenv("TWILIO_AUTH_TOKEN")
 FROM_NUMBER  = os.getenv("TWILIO_FROM_NUMBER")
 TO_NUMBERS   = os.getenv("TWILIO_TO_NUMBERS", "")
+
+# Background polling configuration
+POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "300"))  # seconds
+ENABLE_POLLING = os.getenv("ENABLE_POLLING", "1").lower() not in (
+    "0",
+    "false",
+    "no",
+)
 
 # Google Routes API endpoint + headers
 ROUTES_URL = "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix"
@@ -205,6 +214,42 @@ def check_and_notify():
             continue
         sid = send_sms(body, u["phone"])
         print(f"🔔 Sent to {u['phone']}: {sid}")
+
+
+# ──────────────────── Background scheduler ────────────────────────────────
+_poll_lock = threading.Lock()
+_poll_started = False
+
+
+def start_background_polling():
+    """Launch a daemon thread that periodically runs ``check_and_notify``."""
+    global _poll_started
+    if _poll_started:
+        return
+    _poll_started = True
+    if not ENABLE_POLLING or POLL_INTERVAL <= 0:
+        print("Background polling disabled.")
+        return
+
+    def loop():
+        while True:
+            with _poll_lock:
+                try:
+                    check_and_notify()
+                except Exception as e:
+                    print("Polling error:", e)
+            time.sleep(POLL_INTERVAL)
+
+    threading.Thread(target=loop, daemon=True).start()
+
+
+# Background thread is launched on the first incoming request
+
+
+@app.before_first_request
+def _start_polling() -> None:
+    """Start the background polling thread on the first incoming request."""
+    start_background_polling()
 
 
 # ──────────────────── SMS Webhook helpers ──────────────────────────────────

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 set -e
-python -u bridge_app.py --poll &
 exec gunicorn --bind 0.0.0.0:${WEBSITES_PORT:-${PORT:-8000}} --log-level debug bridge_app:app


### PR DESCRIPTION
## Summary
- add configurable background polling thread so the Flask app schedules `check_and_notify`
- start scheduler on first request, guarded by `ENABLE_POLLING` and `POLL_INTERVAL` env vars
- document environment variables and simplify run script

## Testing
- `python -m py_compile bridge_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904a02939c832384ba3e0bb91bc36e