### PR TITLE
feat: add background polling thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ The application expects the following variables to be defined:
 - `TWILIO_FROM_NUMBER` – The Twilio phone number that sends the alerts.
 - `TWILIO_TO_NUMBERS` – Comma-separated list of recipient numbers for the
   monitor when running without per-user settings.
+- `ENABLE_POLLING` – Set to `0` to disable the background polling thread
+  (defaults to enabled).
+- `POLL_INTERVAL` – Interval in seconds between delay checks. Defaults to
+  `300` seconds. Setting it to `0` also disables polling.
 
 ## Running locally
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 set -e
-python -u bridge_app.py --poll &
 exec gunicorn --bind 0.0.0.0:${WEBSITES_PORT:-${PORT:-8000}} --log-level debug bridge_app:app


### PR DESCRIPTION
## Summary
- add configurable background polling thread so the Flask app schedules `check_and_notify`
- start scheduler on first request, guarded by `ENABLE_POLLING` and `POLL_INTERVAL` env vars
- document environment variables and simplify run script
- replace removed `before_first_request` hook with `before_request` for Flask 3 compatibility

## Testing
- `python -m py_compile bridge_app.py`
- `python bridge_app.py --help`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904a02939c832384ba3e0bb91bc36e