### PR TITLE
feat: persist state and user data in azure tables

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ twilio
 Flask
 gunicorn>=21.2
 flask-cors>=4.0
+azure-data-tables>=12.5
 


### PR DESCRIPTION
## Summary
- store last status and user settings in Azure Table Storage with fallback to local files
- add azure-data-tables requirement

## Testing
- `python -m py_compile bridge_app.py`


------
https://chatgpt.com/codex/tasks/task_e_689aa816c0648323890dfcf1592905e6