### PR TITLE
Add OTP login and settings pages

### DIFF
--- a/web/account/account.css
+++ b/web/account/account.css
@@ -1,0 +1,134 @@
+/* ── TOKENS & RESET ─────────────────────────────────────────────── */
+:root {
+  --bg:          #111316;
+  --panel:       #1e2025;
+  --field:       #181b20;
+  --fg:          #e8e8e8;
+  --fg-muted:    #9ca0a6;
+  --accent:      #0a84ff;
+  --radius:      18px;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui;
+}
+
+/* ── NAVBAR ─────────────────────────────────────────────────────── */
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(24, 27, 32, 0.85);
+  backdrop-filter: blur(8px);
+}
+
+.logo {
+  font-weight: 700;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.navbar nav a {
+  margin-left: 1.5rem;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition: 0.2s;
+}
+
+.navbar nav a:hover {
+  color: var(--fg);
+}
+
+/* ── HERO TAGLINE ──────────────────────────────────────────────── */
+.hero {
+  text-align: center;
+  margin: 4rem auto 3rem;
+  max-width: 700px;
+  padding: 0 1rem;
+}
+
+.hero__title {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+/* ── SIGN‑UP CARD ──────────────────────────────────────────────── */
+.signup {
+  max-width: 650px;
+  margin: 0 auto 6rem;
+  text-align: center;
+  background: var(--panel);
+  border-radius: calc(var(--radius) * 1.6);
+  padding: 3rem 2rem;
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.55);
+}
+
+.signup__title {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  color: var(--accent);
+}
+
+.signup__tagline {
+  margin: 0 0 2rem;
+  color: var(--fg-muted);
+}
+
+/* Form grid: two inputs/row on ≥ 640 px, one per row on mobile */
+.signup__form {
+  display: grid;
+  gap: 1.2rem;
+  margin-bottom: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  justify-content: center;
+}
+
+.signup__form input {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border: none;
+  border-radius: var(--radius);
+  background: var(--field);
+  color: var(--fg);
+  font-size: 1rem;
+}
+
+.signup__form button {
+  grid-column: 1 / -1;               /* full‑width button */
+  padding: 0.9rem 2rem;
+  border: none;
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: 0.15s;
+}
+
+.signup__form button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(10, 132, 255, 0.35);
+}
+
+.signup__note {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+}
+
+/* ── END (add more sections below as needed) ───────────────────── */

--- a/web/account/account.html
+++ b/web/account/account.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BridgeDelay • Account</title>
+  <link rel="stylesheet" href="account.css">
+</head>
+<body>
+  <header class="navbar">
+    <a href="../main.html" class="logo">BridgeDelay</a>
+    <nav>
+      <a href="#" id="logout">Log Out</a>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h1 class="hero__title">Your Settings</h1>
+  </section>
+
+  <section class="signup">
+    <form id="settings-form" class="signup__form">
+      <input type="number" id="threshold" placeholder="Delay threshold (minutes)">
+      <input type="text" id="windows" placeholder="Windows e.g. 07:00-09:00,16:00-18:00">
+      <button type="submit" class="cta">Save</button>
+    </form>
+    <small id="settings-status" class="signup__note"></small>
+  </section>
+
+  <footer class="footer">
+    <p>© 2025 BridgeDelay • Made in 🇨🇦</p>
+  </footer>
+
+  <script src="account.js"></script>
+</body>
+</html>

--- a/web/account/account.js
+++ b/web/account/account.js
@@ -1,0 +1,50 @@
+const token = localStorage.getItem('token');
+if (!token) {
+  window.location.href = '../login/login.html';
+}
+
+const statusEl = document.getElementById('settings-status');
+const form = document.getElementById('settings-form');
+
+async function loadSettings() {
+  const res = await fetch('/api/user/settings', {
+    headers: { 'Authorization': 'Bearer ' + token }
+  });
+  if (res.ok) {
+    const data = await res.json();
+    document.getElementById('threshold').value = data.threshold;
+    const winStr = (data.windows || []).map(w => `${w.start}-${w.end}`).join(',');
+    document.getElementById('windows').value = winStr;
+  } else if (res.status === 401) {
+    localStorage.removeItem('token');
+    window.location.href = '../login/login.html';
+  }
+}
+
+loadSettings();
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const threshold = parseInt(document.getElementById('threshold').value, 10) || 0;
+  const windows = document.getElementById('windows').value.trim();
+  const res = await fetch('/api/user/settings', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + token
+    },
+    body: JSON.stringify({threshold, windows})
+  });
+  if (res.ok) {
+    statusEl.textContent = 'Saved!';
+  } else {
+    const data = await res.json().catch(() => ({}));
+    statusEl.textContent = data.error || 'Error saving settings.';
+  }
+});
+
+document.getElementById('logout').addEventListener('click', (e) => {
+  e.preventDefault();
+  localStorage.removeItem('token');
+  window.location.href = '../login/login.html';
+});

--- a/web/login/login.css
+++ b/web/login/login.css
@@ -1,0 +1,134 @@
+/* ── TOKENS & RESET ─────────────────────────────────────────────── */
+:root {
+  --bg:          #111316;
+  --panel:       #1e2025;
+  --field:       #181b20;
+  --fg:          #e8e8e8;
+  --fg-muted:    #9ca0a6;
+  --accent:      #0a84ff;
+  --radius:      18px;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: system-ui;
+}
+
+/* ── NAVBAR ─────────────────────────────────────────────────────── */
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(24, 27, 32, 0.85);
+  backdrop-filter: blur(8px);
+}
+
+.logo {
+  font-weight: 700;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.navbar nav a {
+  margin-left: 1.5rem;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition: 0.2s;
+}
+
+.navbar nav a:hover {
+  color: var(--fg);
+}
+
+/* ── HERO TAGLINE ──────────────────────────────────────────────── */
+.hero {
+  text-align: center;
+  margin: 4rem auto 3rem;
+  max-width: 700px;
+  padding: 0 1rem;
+}
+
+.hero__title {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+/* ── SIGN‑UP CARD ──────────────────────────────────────────────── */
+.signup {
+  max-width: 650px;
+  margin: 0 auto 6rem;
+  text-align: center;
+  background: var(--panel);
+  border-radius: calc(var(--radius) * 1.6);
+  padding: 3rem 2rem;
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.55);
+}
+
+.signup__title {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  color: var(--accent);
+}
+
+.signup__tagline {
+  margin: 0 0 2rem;
+  color: var(--fg-muted);
+}
+
+/* Form grid: two inputs/row on ≥ 640 px, one per row on mobile */
+.signup__form {
+  display: grid;
+  gap: 1.2rem;
+  margin-bottom: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  justify-content: center;
+}
+
+.signup__form input {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border: none;
+  border-radius: var(--radius);
+  background: var(--field);
+  color: var(--fg);
+  font-size: 1rem;
+}
+
+.signup__form button {
+  grid-column: 1 / -1;               /* full‑width button */
+  padding: 0.9rem 2rem;
+  border: none;
+  border-radius: var(--radius);
+  background: var(--accent);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: 0.15s;
+}
+
+.signup__form button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(10, 132, 255, 0.35);
+}
+
+.signup__note {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+}
+
+/* ── END (add more sections below as needed) ───────────────────── */

--- a/web/login/login.html
+++ b/web/login/login.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BridgeDelay • Log In</title>
+  <link rel="stylesheet" href="login.css">
+</head>
+<body>
+  <header class="navbar">
+    <a href="../main.html" class="logo">BridgeDelay</a>
+    <nav>
+      <a href="../main.html#features">Features</a>
+      <a href="../signup/signup.html">Sign Up</a>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h1 class="hero__title">Log In</h1>
+    <p class="hero__subtitle">Enter your phone number to receive a one-time code.</p>
+  </section>
+
+  <section class="signup">
+    <form id="phone-form" class="signup__form">
+      <input type="tel" id="phone" placeholder="Phone" required>
+      <button type="submit" class="cta">Send Code</button>
+    </form>
+
+    <form id="code-form" class="signup__form" style="display:none">
+      <input type="text" id="code" placeholder="6-digit code" required>
+      <button type="submit" class="cta">Verify</button>
+    </form>
+
+    <small id="login-status" class="signup__note"></small>
+  </section>
+
+  <footer class="footer">
+    <p>© 2025 BridgeDelay • Made in 🇨🇦</p>
+  </footer>
+
+  <script src="login.js"></script>
+</body>
+</html>

--- a/web/login/login.js
+++ b/web/login/login.js
@@ -1,0 +1,39 @@
+const phoneForm = document.getElementById('phone-form');
+const codeForm = document.getElementById('code-form');
+const statusEl = document.getElementById('login-status');
+
+phoneForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const phone = document.getElementById('phone').value.trim();
+  const res = await fetch('/api/otp/start', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({phone})
+  });
+  const data = await res.json();
+  if (data.status === 'sent' || data.status === 'cooldown') {
+    statusEl.textContent = 'Code sent!';
+    phoneForm.style.display = 'none';
+    codeForm.style.display = 'grid';
+  } else {
+    statusEl.textContent = 'Failed to send code.';
+  }
+});
+
+codeForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const phone = document.getElementById('phone').value.trim();
+  const code = document.getElementById('code').value.trim();
+  const res = await fetch('/api/otp/verify', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({phone, code})
+  });
+  const data = await res.json();
+  if (data.ok && data.token) {
+    localStorage.setItem('token', data.token);
+    window.location.href = '../account/account.html';
+  } else {
+    statusEl.textContent = 'Invalid or expired code.';
+  }
+});

--- a/web/main.html
+++ b/web/main.html
@@ -17,6 +17,7 @@
     <nav>
       <a href="#features">Features</a>
       <a href="signup/signup.html">Sign Up</a>
+      <a href="login/login.html">Log In</a>
     </nav>
   </header>
 

--- a/web/signup/signup.html
+++ b/web/signup/signup.html
@@ -16,6 +16,7 @@
     <nav>
       <a href="../main.html#features">Features</a>
       <a href="./" aria-current="page">Sign Up</a>
+      <a href="../login/login.html">Log In</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- Add JWT helper and new `/api/user/settings` endpoint to manage per-user configuration
- Implement login and account pages using existing OTP flow and allow editing threshold and windows
- Link login from main and signup pages

## Testing
- `python -m py_compile bridge_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a16c365af483238d2bbf1f40883525