### PR TITLE
Add FAQ skeleton page and redirect after sign-up verification

### DIFF
--- a/web/faq/faq.css
+++ b/web/faq/faq.css
@@ -1,0 +1,9 @@
+.faq {
+  max-width: 800px;
+  margin: 40px auto;
+  padding: 0 20px;
+}
+
+.faq-item + .faq-item {
+  margin-top: 20px;
+}

--- a/web/faq/faq.html
+++ b/web/faq/faq.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BridgeDelay FAQ</title>
+  <link rel="stylesheet" href="../core.css" />
+  <link rel="stylesheet" href="faq.css" />
+</head>
+<body>
+  <header class="navbar">
+    <a href="../main.html" class="logo">BridgeDelay</a>
+  </header>
+  <main class="faq">
+    <h1>Frequently Asked Questions</h1>
+    <section class="faq-item">
+      <h2>Question 1</h2>
+      <p>Answer to question 1.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/web/signup/signup.js
+++ b/web/signup/signup.js
@@ -106,8 +106,8 @@ function showOtpStep(phone) {
     localStorage.setItem("nv_phone", phone);
 
     setOtpMsg("You're in! Redirecting…", "#065f46");
-    // Redirect to your app homepage or dashboard
-    window.location.href = "/";
+    // Redirect to FAQ page after successful verification
+    window.location.href = "/faq/faq.html";
   };
 
   resendBtn.onclick = async () => {


### PR DESCRIPTION
## Summary
- Add placeholder FAQ page and simple styling for future content
- Redirect users to the FAQ page after successful OTP verification during sign-up

## Testing
- `python -m py_compile bridge_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a55afccd9c8323a17e2d78eec63c29