### PR TITLE
Add FAQ skeleton page and redirect after sign-up verification

### DIFF
--- a/web/faq/faq.css
+++ b/web/faq/faq.css
@@ -1,0 +1,88 @@
+/* FAQ PAGE STYLES - relies on tokens from core.css */
+
+html,
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+/* NAVBAR --------------------------------------------------------- */
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(24, 27, 32, 0.85);
+  backdrop-filter: blur(8px);
+}
+
+.logo {
+  font-weight: 700;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.navbar nav a {
+  margin-left: 1.5rem;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition: 0.2s;
+}
+
+.navbar nav a:hover {
+  color: var(--fg);
+}
+
+/* HERO ----------------------------------------------------------- */
+.hero {
+  text-align: center;
+  margin: 4rem auto 3rem;
+  max-width: 700px;
+  padding: 0 1rem;
+}
+
+.hero__title {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+/* FAQ CONTENT ---------------------------------------------------- */
+.faq {
+  max-width: 800px;
+  margin: 0 auto 6rem;
+  padding: 0 1rem;
+}
+
+.faq-item {
+  background: var(--panel);
+  border-radius: calc(var(--radius) * 1.2);
+  padding: 1.5rem 2rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.faq-item + .faq-item {
+  margin-top: 1.5rem;
+}
+
+.faq-item h2 {
+  margin-top: 0;
+  color: var(--accent);
+}
+
+.faq-item p {
+  margin: 0.75rem 0 0;
+  color: var(--fg-muted);
+}
+
+/* FOOTER --------------------------------------------------------- */
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--fg-muted);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}

--- a/web/faq/faq.html
+++ b/web/faq/faq.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BridgeDelay • FAQ</title>
+  <link rel="stylesheet" href="../core.css" />
+  <link rel="stylesheet" href="faq.css" />
+</head>
+<body>
+  <!-- NAVBAR -->
+  <header class="navbar">
+    <a href="../main.html" class="logo">BridgeDelay</a>
+    <nav>
+      <a href="../main.html#features">Features</a>
+      <a href="../signup/signup.html">Sign Up</a>
+      <a href="../login/login.html">Log In</a>
+    </nav>
+  </header>
+
+  <!-- HERO TAGLINE -->
+  <section class="hero">
+    <h1 class="hero__title">Frequently Asked Questions</h1>
+    <p class="hero__subtitle">Everything you never wanted to know.</p>
+  </section>
+
+  <!-- FAQ CONTENT -->
+  <section class="faq">
+    <article class="faq-item">
+      <h2>What is BridgeDelay?</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </article>
+    <article class="faq-item">
+      <h2>How does it work?</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </article>
+    <article class="faq-item">
+      <h2>Can I trust the alerts?</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </article>
+  </section>
+
+  <footer class="footer">
+    <p>© 2025 BridgeDelay • Made in 🇨🇦</p>
+  </footer>
+</body>
+</html>

--- a/web/signup/signup.js
+++ b/web/signup/signup.js
@@ -106,8 +106,8 @@ function showOtpStep(phone) {
     localStorage.setItem("nv_phone", phone);
 
     setOtpMsg("You're in! Redirecting…", "#065f46");
-    // Redirect to your app homepage or dashboard
-    window.location.href = "/";
+    // Redirect to FAQ page after successful verification
+    window.location.href = "/faq/faq.html";
   };
 
   resendBtn.onclick = async () => {


### PR DESCRIPTION
## Summary
- Add placeholder FAQ page and simple styling for future content
- Redirect users to the FAQ page after successful OTP verification during sign-up

## Testing
- `python -m py_compile bridge_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a55afccd9c8323a17e2d78eec63c29