### PR TITLE
Add commands reference page

### DIFF
--- a/web/commands.css
+++ b/web/commands.css
@@ -1,0 +1,86 @@
+html,
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+/* NAVBAR --------------------------------------------------------- */
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(24, 27, 32, 0.85);
+  backdrop-filter: blur(8px);
+}
+
+.logo {
+  font-weight: 700;
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.navbar nav a {
+  margin-left: 1.5rem;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition: 0.2s;
+}
+
+.navbar nav a:hover {
+  color: var(--fg);
+}
+
+/* HERO ----------------------------------------------------------- */
+.hero {
+  text-align: center;
+  margin: 4rem auto 3rem;
+  max-width: 700px;
+  padding: 0 1rem;
+}
+
+.hero__title {
+  margin: 0 0 0.75rem;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+/* COMMAND LIST --------------------------------------------------- */
+.commands {
+  max-width: 800px;
+  margin: 0 auto 6rem;
+  padding: 0 1rem;
+}
+
+.command-item {
+  background: var(--panel);
+  border-radius: calc(var(--radius) * 1.2);
+  padding: 1.5rem 2rem;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+.command-item + .command-item {
+  margin-top: 1.5rem;
+}
+
+.command-item h2 {
+  margin-top: 0;
+  color: var(--accent);
+}
+
+.command-item p {
+  margin: 0.75rem 0 0;
+  color: var(--fg-muted);
+}
+
+/* FOOTER --------------------------------------------------------- */
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--fg-muted);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}

--- a/web/commands.html
+++ b/web/commands.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BridgeDelay • Commands</title>
+  <link rel="stylesheet" href="core.css" />
+  <link rel="stylesheet" href="commands.css" />
+</head>
+<body>
+  <!-- NAVBAR -->
+  <header class="navbar">
+    <a href="main.html" class="logo">BridgeDelay</a>
+    <nav>
+      <a href="main.html#features">Features</a>
+      <a href="setup/setup.html">Setup</a>
+      <a href="faq/faq.html">FAQ</a>
+      <a href="signup/signup.html">Sign Up</a>
+      <a href="login/login.html">Log In</a>
+    </nav>
+  </header>
+
+  <!-- HERO TAGLINE -->
+  <section class="hero">
+    <h1 class="hero__title">Command Reference</h1>
+    <p class="hero__subtitle">Control BridgeDelay through simple texts.</p>
+  </section>
+
+  <!-- COMMAND LIST -->
+  <section class="commands">
+    <article class="command-item">
+      <h2>STATUS</h2>
+      <p>Get the current bridge status and travel time.</p>
+    </article>
+    <article class="command-item">
+      <h2>THRESHOLD {minutes}</h2>
+      <p>Set how many minutes of delay should trigger an alert.</p>
+    </article>
+    <article class="command-item">
+      <h2>WINDOW {start}-{end}</h2>
+      <p>Specify quiet hours when you don't want alerts.</p>
+    </article>
+    <article class="command-item">
+      <h2>STOP</h2>
+      <p>Pause all alerts until you send START.</p>
+    </article>
+    <article class="command-item">
+      <h2>START</h2>
+      <p>Resume alerts after sending STOP.</p>
+    </article>
+  </section>
+
+  <footer class="footer">
+    <p>© 2025 BridgeDelay • Made in 🇨🇦</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add commands.html page listing available SMS commands
- include commands.css for consistent styling across site

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5632cfbd88323bcebf83dc4f3198d