### PR TITLE
feat: add demo SMS for command reference

### DIFF
--- a/web/commands.css
+++ b/web/commands.css
@@ -51,31 +51,92 @@ body {
 
 /* COMMAND LIST --------------------------------------------------- */
 .commands {
-  max-width: 800px;
+  max-width: 1100px;
   margin: 0 auto 6rem;
   padding: 0 1rem;
 }
 
-.command-item {
-  background: var(--panel);
+.sms-pair {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: flex-start;
+  padding: 2.75rem;
+  margin-bottom: 4.5rem;
+  background: #1d1f23;
+  border-radius: calc(var(--radius) * 1.6);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.55);
+  overflow: visible;
+}
+
+.sms-copy {
+  flex: 1 1 250px;
+  min-width: 230px;
+  padding-right: 1.25rem;
+}
+
+.sms-copy h2 { margin-top: 0; color: var(--accent); }
+.sms-copy p  { color: var(--fg-muted); }
+
+.bubbles-wrap {
+  flex: 1 1 260px;
+  min-width: 250px;
+  padding: 1.25rem 1.75rem;
+  background: #31343d;
   border-radius: calc(var(--radius) * 1.2);
-  padding: 1.5rem 2rem;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+  transform: translateY(-6px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
 }
 
-.command-item + .command-item {
-  margin-top: 1.5rem;
+.bubbles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
 }
 
-.command-item h2 {
-  margin-top: 0;
-  color: var(--accent);
+.bubble {
+  max-width: 260px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  border-radius: calc(var(--radius) * 1.2);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.55);
 }
 
-.command-item p {
-  margin: 0.75rem 0 0;
-  color: var(--fg-muted);
+.bubble.in  { background: var(--bg-alt); }
+.bubble.out { background: var(--accent); color: #fff; align-self: flex-end; }
+
+@media (max-width: 700px) {
+  .sms-pair {
+    display: block;
+    padding: 1rem;
+    row-gap: 0.85rem;
+  }
+  .sms-copy { margin-bottom: 0.85rem; }
+  .sms-copy p { margin: 0; }
+  .bubbles-wrap {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 0.85rem;
+    background: #31343d;
+    border-radius: calc(var(--radius) * 1.2);
+    transform: none;
+  }
+  .bubble {
+    width: 94%;
+    max-width: 94%;
+    align-self: center;
+  }
 }
+
+/* same when dev toggle forces mobile ------------------------- */
+body.force-mobile .sms-pair       { display:block;padding:1rem;row-gap:.85rem; }
+body.force-mobile .sms-copy       { margin-bottom:.85rem; }
+body.force-mobile .sms-copy p     { margin:0; }
+body.force-mobile .bubbles-wrap   { display:flex;flex-direction:column;width:100%;padding:.85rem;background:#31343d;border-radius:calc(var(--radius)*1.2);transform:none; }
+body.force-mobile .bubble         { width:94%;max-width:94%;align-self:center; }
 
 /* FOOTER --------------------------------------------------------- */
 .footer {

--- a/web/commands.html
+++ b/web/commands.html
@@ -28,26 +28,70 @@
 
   <!-- COMMAND LIST -->
   <section class="commands">
-    <article class="command-item">
-      <h2>STATUS</h2>
-      <p>Get the current bridge status and travel time.</p>
-    </article>
-    <article class="command-item">
-      <h2>THRESHOLD {minutes}</h2>
-      <p>Set how many minutes of delay should trigger an alert.</p>
-    </article>
-    <article class="command-item">
-      <h2>WINDOW {start}-{end}</h2>
-      <p>Specify quiet hours when you don't want alerts.</p>
-    </article>
-    <article class="command-item">
-      <h2>STOP</h2>
-      <p>Pause all alerts until you send START.</p>
-    </article>
-    <article class="command-item">
-      <h2>START</h2>
-      <p>Resume alerts after sending STOP.</p>
-    </article>
+    <div class="sms-pair">
+      <div class="sms-copy">
+        <h2>STATUS</h2>
+        <p>Get the current bridge status and travel time.</p>
+      </div>
+      <div class="bubbles-wrap">
+        <div class="bubbles">
+          <div class="bubble out">Status?</div>
+          <div class="bubble in">✅ Bridge is clear — 8&nbsp;min travel time.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="sms-pair">
+      <div class="sms-copy">
+        <h2>THRESHOLD {minutes}</h2>
+        <p>Set how many minutes of delay should trigger an alert.</p>
+      </div>
+      <div class="bubbles-wrap">
+        <div class="bubbles">
+          <div class="bubble out">THRESHOLD 20</div>
+          <div class="bubble in">Alerts for delays ≥ 20&nbsp;min.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="sms-pair">
+      <div class="sms-copy">
+        <h2>WINDOW {start}-{end}</h2>
+        <p>Specify quiet hours when you don't want alerts.</p>
+      </div>
+      <div class="bubbles-wrap">
+        <div class="bubbles">
+          <div class="bubble out">WINDOW 7-9</div>
+          <div class="bubble in">📅 Quiet hours set for 7–9.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="sms-pair">
+      <div class="sms-copy">
+        <h2>STOP</h2>
+        <p>Pause all alerts until you send START.</p>
+      </div>
+      <div class="bubbles-wrap">
+        <div class="bubbles">
+          <div class="bubble out">STOP</div>
+          <div class="bubble in">Alerts paused. Text START to resume.</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="sms-pair">
+      <div class="sms-copy">
+        <h2>START</h2>
+        <p>Resume alerts after sending STOP.</p>
+      </div>
+      <div class="bubbles-wrap">
+        <div class="bubbles">
+          <div class="bubble out">START</div>
+          <div class="bubble in">Alerts resumed. Welcome back!</div>
+        </div>
+      </div>
+    </div>
   </section>
 
   <footer class="footer">


### PR DESCRIPTION
## Summary
- add SMS-style examples to command reference page
- style command page with bubble layout and mobile fixes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5649fca348323a66561ef81684b54