### PR TITLE
Expand navigation and polish settings page

### DIFF
--- a/web/account/account.css
+++ b/web/account/account.css
@@ -90,13 +90,25 @@ body {
   color: var(--fg-muted);
 }
 
-/* Form grid: two inputs/row on ≥ 640 px, one per row on mobile */
+/* Settings form styling */
 .signup__form {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1.2rem;
   margin-bottom: 1.8rem;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  justify-content: center;
+}
+
+.signup__form .field {
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.signup__form label {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--fg);
 }
 
 .signup__form input {
@@ -110,7 +122,6 @@ body {
 }
 
 .signup__form button {
-  grid-column: 1 / -1;               /* full‑width button */
   padding: 0.9rem 2rem;
   border: none;
   border-radius: var(--radius);

--- a/web/account/account.html
+++ b/web/account/account.html
@@ -10,6 +10,10 @@
   <header class="navbar">
     <a href="../main.html" class="logo">BridgeDelay</a>
     <nav>
+      <a href="../main.html#features">Features</a>
+      <a href="../setup/setup.html">Setup</a>
+      <a href="../faq/faq.html">FAQ</a>
+      <a href="../commands.html">Commands</a>
       <a href="#" id="logout">Log Out</a>
     </nav>
   </header>
@@ -20,8 +24,14 @@
 
   <section class="signup">
     <form id="settings-form" class="signup__form">
-      <input type="number" id="threshold" placeholder="Delay threshold (minutes)">
-      <input type="text" id="windows" placeholder="Windows e.g. 07:00-09:00,16:00-18:00">
+      <div class="field">
+        <label for="threshold">Delay threshold (minutes)</label>
+        <input type="number" id="threshold" placeholder="20">
+      </div>
+      <div class="field">
+        <label for="windows">Quiet hours <small>(e.g., 07:00-09:00,16:00-18:00)</small></label>
+        <input type="text" id="windows" placeholder="07:00-09:00,16:00-18:00">
+      </div>
       <button type="submit" class="cta">Save</button>
     </form>
     <small id="settings-status" class="signup__note"></small>

--- a/web/commands.html
+++ b/web/commands.html
@@ -15,6 +15,7 @@
       <a href="main.html#features">Features</a>
       <a href="setup/setup.html">Setup</a>
       <a href="faq/faq.html">FAQ</a>
+      <a href="commands.html" aria-current="page">Commands</a>
       <a href="signup/signup.html">Sign Up</a>
       <a href="login/login.html">Log In</a>
     </nav>

--- a/web/faq/faq.html
+++ b/web/faq/faq.html
@@ -14,6 +14,7 @@
     <nav>
       <a href="../main.html#features">Features</a>
       <a href="../setup/setup.html">Setup</a>
+      <a href="../commands.html">Commands</a>
       <a href="../signup/signup.html">Sign Up</a>
       <a href="../login/login.html">Log In</a>
     </nav>

--- a/web/login/login.html
+++ b/web/login/login.html
@@ -11,6 +11,9 @@
     <a href="../main.html" class="logo">BridgeDelay</a>
     <nav>
       <a href="../main.html#features">Features</a>
+      <a href="../setup/setup.html">Setup</a>
+      <a href="../faq/faq.html">FAQ</a>
+      <a href="../commands.html">Commands</a>
       <a href="../signup/signup.html">Sign Up</a>
     </nav>
   </header>

--- a/web/main.html
+++ b/web/main.html
@@ -16,6 +16,9 @@
     <a href="#" class="logo">BridgeDelay</a>
     <nav>
       <a href="#features">Features</a>
+      <a href="setup/setup.html">Setup</a>
+      <a href="faq/faq.html">FAQ</a>
+      <a href="commands.html">Commands</a>
       <a href="signup/signup.html">Sign Up</a>
       <a href="login/login.html">Log In</a>
     </nav>

--- a/web/setup/setup.html
+++ b/web/setup/setup.html
@@ -14,6 +14,7 @@
     <nav>
       <a href="../main.html#features">Features</a>
       <a href="../faq/faq.html">FAQ</a>
+      <a href="../commands.html">Commands</a>
       <a href="../signup/signup.html">Sign Up</a>
       <a href="../login/login.html">Log In</a>
     </nav>
@@ -29,11 +30,11 @@
   <section class="setup">
     <article class="step-item">
       <h2>Set your notification windows</h2>
-      <p>To make sure you only get delays when you actually need them, set your notification windows in user settings or through text to match your schedule.</p>
+      <p>To make sure you only get delays when you actually need them, set your notification windows in <a href="../account/account.html">user settings</a> or through text to match your schedule.</p>
     </article>
     <article class="step-item">
       <h2>Set your threshold</h2>
-      <p>To make sure you only get alerts for significant delays, set your threshold in user settings or through text by sending "Threshold {time in minutes}". By default this value is 20 minutes.</p>
+      <p>To make sure you only get alerts for significant delays, set your threshold in <a href="../account/account.html">user settings</a> or through text by sending "Threshold {time in minutes}". By default this value is 20 minutes.</p>
     </article>
     <article class="step-item">
       <h2>Get familiar with the commands</h2>

--- a/web/signup/signup.html
+++ b/web/signup/signup.html
@@ -15,6 +15,9 @@
     <a href="../main.html" class="logo">BridgeDelay</a>
     <nav>
       <a href="../main.html#features">Features</a>
+      <a href="../setup/setup.html">Setup</a>
+      <a href="../faq/faq.html">FAQ</a>
+      <a href="../commands.html">Commands</a>
       <a href="./" aria-current="page">Sign Up</a>
       <a href="../login/login.html">Log In</a>
     </nav>

--- a/web/signup/signup.js
+++ b/web/signup/signup.js
@@ -101,9 +101,9 @@ function showOtpStep(phone) {
 
     // Store JWT if backend returned one
     if (r.data?.token) {
-      localStorage.setItem("nv_token", r.data.token);
+      localStorage.setItem("token", r.data.token);
     }
-    localStorage.setItem("nv_phone", phone);
+    localStorage.setItem("phone", phone);
 
     setOtpMsg("You're in! Redirecting…", "#065f46");
     // Redirect to Setup page after successful verification


### PR DESCRIPTION
## Summary
- Add Setup, FAQ, and Commands links to navbars across the site
- Store JWT on signup to keep users logged in automatically
- Link setup instructions to account settings and refine settings page layout

## Testing
- `python -m py_compile bridge_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a56955a7fc8323a2190fa1dee24d51