### PR TITLE
Add per-direction delay thresholds

### DIFF
--- a/user_settings.json
+++ b/user_settings.json
@@ -1,7 +1,8 @@
 [
   {
     "phone": "+14161234567",
-    "threshold": 25,
+    "threshold_nb": 25,
+    "threshold_sb": 25,
     "windows": [
       {
         "start": "07:00",
@@ -17,7 +18,8 @@
   },
   {
     "phone": "+16729991314",
-    "threshold": 5,
+    "threshold_nb": 5,
+    "threshold_sb": 5,
     "windows": [
       {
         "start": "00:00",

--- a/web/account/account.html
+++ b/web/account/account.html
@@ -25,8 +25,12 @@
   <section class="signup">
     <form id="settings-form" class="signup__form">
       <div class="field">
-        <label for="threshold">Delay threshold (minutes)</label>
-        <input type="number" id="threshold" placeholder="20">
+        <label for="threshold_nb">Northbound threshold (minutes)</label>
+        <input type="number" id="threshold_nb" placeholder="20">
+      </div>
+      <div class="field">
+        <label for="threshold_sb">Southbound threshold (minutes)</label>
+        <input type="number" id="threshold_sb" placeholder="20">
       </div>
       <div class="field">
         <label for="windows">Alert windows & direction <small>(e.g., 06:00-09:00 SB,16:00-20:00 NB)</small></label>

--- a/web/account/account.js
+++ b/web/account/account.js
@@ -19,7 +19,8 @@ async function loadSettings() {
     }
     if (!res.ok) throw new Error();
     const data = await res.json();
-    document.getElementById('threshold').value = data.threshold ?? 0;
+    document.getElementById('threshold_nb').value = data.threshold_nb ?? 0;
+    document.getElementById('threshold_sb').value = data.threshold_sb ?? 0;
     const winStr = (data.windows || []).map(w => `${w.start}-${w.end} ${w.dir}`).join(',');
     document.getElementById('windows').value = winStr;
   } catch {
@@ -29,7 +30,8 @@ async function loadSettings() {
 
 form.addEventListener('submit', async (e) => {
   e.preventDefault();
-  const threshold = parseInt(document.getElementById('threshold').value, 10) || 0;
+  const threshold_nb = parseInt(document.getElementById('threshold_nb').value, 10) || 0;
+  const threshold_sb = parseInt(document.getElementById('threshold_sb').value, 10) || 0;
   const windows = document.getElementById('windows').value.trim();
   try {
     const res = await fetch(`${API_BASE}/api/user/settings`, {
@@ -38,7 +40,7 @@ form.addEventListener('submit', async (e) => {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + token
       },
-      body: JSON.stringify({ threshold, windows })
+      body: JSON.stringify({ threshold_nb, threshold_sb, windows })
     });
     if (res.status === 401) {
       localStorage.removeItem('token');

--- a/web/commands.html
+++ b/web/commands.html
@@ -44,13 +44,13 @@
 
     <div class="sms-pair">
       <div class="sms-copy">
-        <h2>THRESHOLD {minutes}</h2>
-        <p>Set how many minutes of delay should trigger an alert. <br /> <br /> DEFAULT: <br />20&nbsp;Minutes</p>
+        <h2>THRESHOLD {dir} {minutes}</h2>
+        <p>Set per-direction alert thresholds. <br /> <br /> DEFAULT: <br />20&nbsp;Minutes for both directions</p>
       </div>
       <div class="bubbles-wrap">
         <div class="bubbles">
-          <div class="bubble out">THRESHOLD 25</div>
-          <div class="bubble in">Got it, your threshold is now set to 25&nbsp;minutes.</div>
+          <div class="bubble out">THRESHOLD NB 25</div>
+          <div class="bubble in">Northbound threshold set to 25&nbsp;minutes.</div>
         </div>
       </div>
     </div>

--- a/web/setup/setup.html
+++ b/web/setup/setup.html
@@ -33,8 +33,8 @@
       <p>Specify when and which direction you travel. For example, you can receive southbound updates in the morning and northbound in the evening. Configure this in <a href="../account/account.html">user settings</a> or via text.</p>
     </article>
     <article class="step-item">
-      <h2>Set your threshold</h2>
-      <p>To make sure you only get alerts for significant delays, set your threshold in <a href="../account/account.html">user settings</a> or through text by sending "Threshold {time in minutes}". By default this value is 20 minutes.</p>
+      <h2>Set your thresholds</h2>
+      <p>To make sure you only get alerts for significant delays, set northbound and southbound thresholds in <a href="../account/account.html">user settings</a> or through text by sending "Threshold NB {time}" or "Threshold SB {time}". By default both values are 20 minutes.</p>
     </article>
     <article class="step-item">
       <h2>Get familiar with the commands</h2>


### PR DESCRIPTION
## Summary
- Store separate northbound and southbound delay thresholds in user settings and API, defaulting to 20 minutes each.
- Compare direction-appropriate thresholds when broadcasting delay alerts and allow SMS/REST clients to manage them.
- Update account UI, setup guide, and command reference for per-direction threshold configuration.

## Testing
- `python -m py_compile bridge_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f57d4e148323a60652b88574a588