### PR TITLE
feat: refine direction alerts and document default windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # BridgeDelay
 
 A simple monitor that polls Google Maps for Lions Gate Bridge travel times and
-sends SMS alerts when delay severity changes. It also exposes a Twilio SMS
-webhook so users can adjust alert preferences or query the current status on
-demand.
+sends SMS alerts when delay severity changes or the delay jumps by at least 15
+minutes since the last alert. It also exposes a Twilio SMS webhook so users can
+adjust alert preferences or query the current status on demand. By default, the
+app sends southbound alerts in the morning (06:30–08:30) and northbound alerts
+in the evening (16:30–19:30). The first alert after each window starts reminds
+you to reply "PAUSE" if you need to silence notifications.
 
 ## Environment variables
 
@@ -13,14 +16,14 @@ Set the following variables before running the app:
 - `TWILIO_ACCOUNT_SID` – Twilio account SID used to send SMS.
 - `TWILIO_AUTH_TOKEN` – Twilio auth token.
 - `TWILIO_FROM_NUMBER` – The Twilio phone number that sends the alerts.
- codex/add-background-job-for-notifications
 - `TWILIO_TO_NUMBERS` – Comma-separated list of recipient numbers for the
   monitor when running without per-user settings.
 - `ENABLE_POLLING` – Set to `0` to disable the background polling thread.
 - `POLL_INTERVAL` – Interval in seconds between delay checks. Defaults to
-  `300` seconds. Setting it to `0` also disables polling.
-  The thread starts automatically on the first request.
-
+  `300` seconds. Setting it to `0` also disables polling. The thread starts
+  automatically on the first request.
+- `NOTIFY_MIN_STEP` – Minimum change in delay (minutes) from the last message
+  before another alert is sent for the same direction. Defaults to `15`.
 
 ## Running locally
 

--- a/web/account/account.html
+++ b/web/account/account.html
@@ -33,8 +33,8 @@
         <input type="number" id="threshold_sb" placeholder="20">
       </div>
       <div class="field">
-        <label for="windows">Alert windows & direction <small>(e.g., 06:00-09:00 SB,16:00-20:00 NB)</small></label>
-        <input type="text" id="windows" placeholder="06:00-09:00 SB,16:00-20:00 NB">
+        <label for="windows">Alert windows & direction <small>(e.g., 06:30-08:30 SB,16:30-19:30 NB)</small></label>
+        <input type="text" id="windows" placeholder="06:30-08:30 SB,16:30-19:30 NB">
       </div>
       <button type="submit" class="cta">Save</button>
     </form>

--- a/web/setup/setup.html
+++ b/web/setup/setup.html
@@ -30,12 +30,13 @@
   <section class="setup">
     <article class="step-item">
       <h2>Set your notification windows</h2>
-      <p>Specify when and which direction you travel. For example, you can receive southbound updates in the morning and northbound in the evening. Configure this in <a href="../account/account.html">user settings</a> or via text.</p>
+      <p>Specify when and which direction you travel. By default, mornings (6:30–8:30 a.m.) send southbound updates and evenings (4:30–7:30 p.m.) send northbound updates. Configure this in <a href="../account/account.html">user settings</a> or via text.</p>
     </article>
     <article class="step-item">
       <h2>Set your thresholds</h2>
       <p>To make sure you only get alerts for significant delays, set northbound and southbound thresholds in <a href="../account/account.html">user settings</a> or through text by sending "Threshold NB {time}" or "Threshold SB {time}". By default both values are 20 minutes.</p>
-    </article>
+      <p>Alerts repeat only if the delay changes by 15 minutes or the severity level shifts since the last message.</p>
+      </article>
     <article class="step-item">
       <h2>Get familiar with the commands</h2>
       <p>There are multiple commands that will make your experience with my app smoother and more efficient. To see a list of commands, <a href="../commands.html">click here</a>.</p>


### PR DESCRIPTION
## Summary
- restrict alerts to the chosen direction and re-send only after a 15‑minute change
- default commute windows now 06:30–08:30 southbound and 16:30–19:30 northbound; first alerts include a pause hint
- website and docs updated to reflect the new default windows

## Testing
- `python -m py_compile bridge_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b39fba3a3c8323b876fe88f4186785