### PR TITLE
Support Twilio API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ Set the following variables before running the app:
 
 - `GOOGLE_MAPS_API_KEY` – Google Maps Routes API key used for delay lookups.
 - `TWILIO_ACCOUNT_SID` – Twilio account SID used to send SMS.
-- `TWILIO_AUTH_TOKEN` – Twilio auth token.
+- `TWILIO_AUTH_TOKEN` – Twilio auth token (required unless using the API key
+  pair below).
+- `TWILIO_API_KEY`/`TWILIO_API_SECRET` – Optional API key credentials. When
+  both are present along with `TWILIO_ACCOUNT_SID`, they are used instead of
+  `TWILIO_AUTH_TOKEN`.
 - `TWILIO_FROM_NUMBER` – The Twilio phone number that sends the alerts.
 - `TWILIO_TO_NUMBERS` – Comma-separated list of recipient numbers for the
   monitor when running without per-user settings.
+- `JWT_SECRET`/`OTP_SIGNING_KEY` – Secret used to sign OTP login tokens.
 - `ENABLE_POLLING` – Set to `0` to disable the background polling thread.
 - `POLL_INTERVAL` – Interval in seconds between delay checks. Defaults to
   `300` seconds. Setting it to `0` also disables polling. The thread starts
@@ -65,6 +70,7 @@ docker run -p 80:8000 \
   -e TWILIO_AUTH_TOKEN=... \
   -e TWILIO_FROM_NUMBER=... \
   -e TWILIO_TO_NUMBERS=... \
+  -e JWT_SECRET=... \
   bridgedelay
 ```
 

--- a/bridge_app.py
+++ b/bridge_app.py
@@ -94,6 +94,8 @@ GOOGLE_KEY   = os.getenv("GOOGLE_MAPS_API_KEY")
 ACCOUNT_SID  = os.getenv("TWILIO_ACCOUNT_SID")
 AUTH_TOKEN   = os.getenv("TWILIO_AUTH_TOKEN")
 FROM_NUMBER  = os.getenv("TWILIO_FROM_NUMBER")
+API_KEY      = os.getenv("TWILIO_API_KEY")
+API_SECRET   = os.getenv("TWILIO_API_SECRET")
 
 TABLES_ENDPOINT = os.getenv("TABLES_ENDPOINT")  # https://<acct>.table.core.windows.net
 AZURE_CONN      = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
@@ -101,7 +103,8 @@ AZURE_CONN      = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
 POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "300"))
 ENABLE_POLLING = os.getenv("ENABLE_POLLING", "1").lower() not in ("0", "false", "no")
 
-JWT_SECRET  = os.getenv("JWT_SECRET")
+# JWT tokens can be signed with either JWT_SECRET or legacy OTP_SIGNING_KEY
+JWT_SECRET  = os.getenv("JWT_SECRET") or os.getenv("OTP_SIGNING_KEY")
 JWT_TTL_MIN = int(os.getenv("JWT_TTL_MIN", "43200"))  # 30 days
 
 NOTIFY_MIN_STEP    = int(os.getenv("NOTIFY_MIN_STEP", "15"))
@@ -268,8 +271,22 @@ def get_user_settings():
     return load_user_settings()
 
 # ──────────────────── Twilio helpers ───────────────────────────────────────
+def _twilio_client() -> Client:
+    """Return a Twilio client using either auth token or API key creds."""
+    if ACCOUNT_SID and AUTH_TOKEN:
+        # Legacy auth token credentials (most deployments)
+        return Client(ACCOUNT_SID, AUTH_TOKEN)
+    if API_KEY and API_SECRET and ACCOUNT_SID:
+        # Optional API key/secret authentication
+        return Client(API_KEY, API_SECRET, ACCOUNT_SID)
+    raise RuntimeError(
+        "Twilio credentials not configured: set TWILIO_ACCOUNT_SID with "
+        "TWILIO_AUTH_TOKEN or TWILIO_API_KEY/TWILIO_API_SECRET"
+    )
+
+
 def send_sms(body: str, to: str) -> str:
-    client = Client(ACCOUNT_SID, AUTH_TOKEN)
+    client = _twilio_client()
     msg = client.messages.create(body=body, from_=FROM_NUMBER, to=to)
     return msg.sid
 


### PR DESCRIPTION
## Summary
- allow Twilio API key/secret credentials in addition to auth token
- document new optional Twilio API key variables
- accept OTP_SIGNING_KEY for JWT signing
- clarify Twilio credential fallback and error messaging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4dae3cda08323b809c45db554dca4