### PR TITLE
Remove Messaging Service fallback for Twilio SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ Set the following variables before running the app:
 
 - `GOOGLE_MAPS_API_KEY` – Google Maps Routes API key used for delay lookups.
 - `TWILIO_ACCOUNT_SID` – Twilio account SID used to send SMS.
-- `TWILIO_AUTH_TOKEN` – Twilio auth token (required unless using the API key
-  pair below).
-- `TWILIO_API_KEY`/`TWILIO_API_SECRET` – Optional API key credentials. When
-  both are present along with `TWILIO_ACCOUNT_SID`, they are used instead of
-  `TWILIO_AUTH_TOKEN`.
+- `TWILIO_AUTH_TOKEN` – Twilio auth token used to authenticate API requests.
 - `TWILIO_FROM_NUMBER` – The Twilio phone number that sends the alerts.
 - `TWILIO_TO_NUMBERS` – Comma-separated list of recipient numbers for the
   monitor when running without per-user settings.

--- a/bridge_app.py
+++ b/bridge_app.py
@@ -94,8 +94,6 @@ GOOGLE_KEY   = os.getenv("GOOGLE_MAPS_API_KEY")
 ACCOUNT_SID  = os.getenv("TWILIO_ACCOUNT_SID")
 AUTH_TOKEN   = os.getenv("TWILIO_AUTH_TOKEN")
 FROM_NUMBER  = os.getenv("TWILIO_FROM_NUMBER")
-API_KEY      = os.getenv("TWILIO_API_KEY")
-API_SECRET   = os.getenv("TWILIO_API_SECRET")
 
 TABLES_ENDPOINT = os.getenv("TABLES_ENDPOINT")  # https://<acct>.table.core.windows.net
 AZURE_CONN      = os.getenv("AZURE_STORAGE_CONNECTION_STRING")
@@ -271,22 +269,8 @@ def get_user_settings():
     return load_user_settings()
 
 # ──────────────────── Twilio helpers ───────────────────────────────────────
-def _twilio_client() -> Client:
-    """Return a Twilio client using either auth token or API key creds."""
-    if ACCOUNT_SID and AUTH_TOKEN:
-        # Legacy auth token credentials (most deployments)
-        return Client(ACCOUNT_SID, AUTH_TOKEN)
-    if API_KEY and API_SECRET and ACCOUNT_SID:
-        # Optional API key/secret authentication
-        return Client(API_KEY, API_SECRET, ACCOUNT_SID)
-    raise RuntimeError(
-        "Twilio credentials not configured: set TWILIO_ACCOUNT_SID with "
-        "TWILIO_AUTH_TOKEN or TWILIO_API_KEY/TWILIO_API_SECRET"
-    )
-
-
 def send_sms(body: str, to: str) -> str:
-    client = _twilio_client()
+    client = Client(ACCOUNT_SID, AUTH_TOKEN)
     msg = client.messages.create(body=body, from_=FROM_NUMBER, to=to)
     return msg.sid
 


### PR DESCRIPTION
## Summary
- revert to simple Twilio configuration using account SID, auth token, and from number
- remove optional Messaging Service SID support

## Testing
- `python -m py_compile bridge_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e354fb9c8323bed62d5ef5cb9b99