### PR TITLE
Improve error handling for external API failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ azure-identity
 azure-data-tables>=12.5
 Flask-Limiter>=3.5
 PyJWT>=2.8.0
+phonenumbers
 


### PR DESCRIPTION
## Summary
- Make Twilio SMS helper surface clearer errors
- Provide descriptive Routes API failures without leaking raw HTTP errors
- Fallback to cached delays and sanitize commands so `STATUS` SMS requests work reliably

## Testing
- `python -m py_compile bridge_app.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68b540396564832386f83cecf8d230bb