### PR TITLE
Restart gunicorn automatically to keep container alive

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,17 +3,61 @@ set -euo pipefail
 
 PORT_TO_BIND="${WEBSITES_PORT:-${PORT:-8000}}"
 
-# Start the polling loop in the background (single instance)
-if [[ "${ENABLE_POLLING:-1}" != "0" ]]; then
-  echo "[run.sh] launching poller (interval: ${POLL_INTERVAL:-300}s)"
-  python -u bridge_app.py --poll &
-fi
+poller_pid=""
+gunicorn_pid=""
+shutdown_requested=0
+
+cleanup() {
+  shutdown_requested=1
+  if [[ -n "${gunicorn_pid}" ]]; then
+    kill "${gunicorn_pid}" 2>/dev/null || true
+    wait "${gunicorn_pid}" 2>/dev/null || true
+    gunicorn_pid=""
+  fi
+  if [[ -n "${poller_pid}" ]]; then
+    echo "[run.sh] stopping poller"
+    kill "${poller_pid}" 2>/dev/null || true
+    wait "${poller_pid}" 2>/dev/null || true
+    poller_pid=""
+  fi
+}
+
+trap cleanup TERM INT
+
+start_poller() {
+  if [[ "${ENABLE_POLLING:-1}" != "0" ]]; then
+    echo "[run.sh] launching poller (interval: ${POLL_INTERVAL:-300}s)"
+    python -u bridge_app.py --poll &
+    poller_pid=$!
+  fi
+}
+
+start_gunicorn() {
+  echo "[run.sh] starting gunicorn on ${PORT_TO_BIND} (workers=${WEB_CONCURRENCY})"
+  gunicorn \
+    --bind "0.0.0.0:${PORT_TO_BIND}" \
+    --workers "${WEB_CONCURRENCY}" \
+    --log-level info \
+    bridge_app:app &
+  gunicorn_pid=$!
+}
 
 # One worker avoids duplicate sends
 : "${WEB_CONCURRENCY:=1}"
-echo "[run.sh] starting gunicorn on ${PORT_TO_BIND} (workers=${WEB_CONCURRENCY})"
-exec gunicorn \
-  --bind "0.0.0.0:${PORT_TO_BIND}" \
-  --workers "${WEB_CONCURRENCY}" \
-  --log-level info \
-  bridge_app:app
+
+start_poller
+
+# Restart gunicorn automatically if it exits unexpectedly
+while true; do
+  start_gunicorn
+  wait "${gunicorn_pid}"
+  exit_code=$?
+  if [[ "${shutdown_requested}" -eq 1 ]]; then
+    break
+  fi
+  echo "[run.sh] gunicorn exited with code ${exit_code}, restarting..."
+  sleep 1
+done
+
+cleanup
+exit "$exit_code"


### PR DESCRIPTION
## Summary
- restart gunicorn automatically if it exits so the container keeps running
- keep polling loop and add shutdown flag for orderly termination

## Testing
- `bash -n run.sh`
- `python -m py_compile bridge_app.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement phonenumbers)*

------
https://chatgpt.com/codex/tasks/task_e_68b5593c3d6c8323b869954e50387c74