### PR TITLE
Add mobile dropdown nav and theme toggle

### DIFF
--- a/web/core.css
+++ b/web/core.css
@@ -1,13 +1,41 @@
 /* ── CORE TOKENS & RESET (shared by every page) ───── */
 :root{
-  --bg:#111316;
+  color-scheme: dark;
+  --bg:#0f1115;
   --bg-alt:#181b20;
-  --panel:#1e2025;
-  --bubble:#181b20;
-  --fg:#e8e8e8;
-  --fg-muted:#9ca0a6;
+  --panel:#1f232b;
+  --panel-strong:#262c35;
+  --bubble:#202530;
+  --fg:#f5f7fa;
+  --fg-muted:#c7ccd7;
   --accent:#0a84ff;
+  --border-soft:rgba(255,255,255,0.08);
+  --navbar-bg:rgba(31,35,43,0.88);
+  --shadow-sm:0 4px 12px rgba(0,0,0,0.25);
+  --shadow-md:0 8px 24px rgba(0,0,0,0.5);
+  --shadow-lg:0 14px 38px rgba(0,0,0,0.55);
+  --shadow-xl:0 16px 44px rgba(0,0,0,0.55);
+  --shadow-hover:0 10px 25px rgba(0,0,0,0.35);
   --radius:18px;
+}
+
+body[data-theme="light"]{
+  color-scheme: light;
+  --bg:#f7f9fc;
+  --bg-alt:#e9edf5;
+  --panel:#ffffff;
+  --panel-strong:#edf2fb;
+  --bubble:#f1f5ff;
+  --fg:#1c2533;
+  --fg-muted:#4a566d;
+  --accent:#0a84ff;
+  --border-soft:rgba(15,23,42,0.12);
+  --navbar-bg:rgba(255,255,255,0.88);
+  --shadow-sm:0 6px 16px rgba(15,23,42,0.12);
+  --shadow-md:0 10px 28px rgba(15,23,42,0.16);
+  --shadow-lg:0 18px 38px rgba(15,23,42,0.18);
+  --shadow-xl:0 22px 46px rgba(15,23,42,0.22);
+  --shadow-hover:0 12px 26px rgba(15,23,42,0.18);
 }
 
 *,

--- a/web/main.html
+++ b/web/main.html
@@ -14,13 +14,18 @@
   <!-- ── NAVBAR ─────────────────────────────────────────────── -->
   <header class="navbar">
     <a href="#" class="logo">BridgeDelay</a>
-    <nav>
+    <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+      <span class="nav-toggle__icon" aria-hidden="true">☰</span>
+      <span class="nav-toggle__label">Menu</span>
+    </button>
+    <nav id="primary-nav" class="navbar__links">
       <a href="#features">Features</a>
       <a href="setup/setup.html">Setup</a>
       <a href="faq/faq.html">FAQ</a>
       <a href="commands.html">Commands</a>
       <a href="signup/signup.html">Sign Up</a>
       <a href="login/login.html">Log In</a>
+      <button type="button" class="theme-toggle" aria-pressed="false">Light mode</button>
     </nav>
   </header>
 

--- a/web/main.js
+++ b/web/main.js
@@ -23,6 +23,124 @@ document.addEventListener("DOMContentLoaded", () => {
     { threshold: 0.15 }
   );
   revealEls.forEach(el => observer.observe(el));
+
+  /* 3. mobile navigation dropdown */
+  const navToggle = document.querySelector(".nav-toggle");
+  const navMenu   = document.getElementById("primary-nav");
+
+  if (navToggle && navMenu) {
+    const mobileQuery   = window.matchMedia("(max-width: 820px)");
+    const isMobileView  = () => mobileQuery.matches;
+
+    const closeNav = () => {
+      navMenu.classList.remove("is-open");
+      navToggle.setAttribute("aria-expanded", "false");
+      if (isMobileView()) {
+        navMenu.setAttribute("aria-hidden", "true");
+      } else {
+        navMenu.removeAttribute("aria-hidden");
+      }
+    };
+
+    const openNav = () => {
+      navMenu.classList.add("is-open");
+      navToggle.setAttribute("aria-expanded", "true");
+      navMenu.removeAttribute("aria-hidden");
+    };
+
+    closeNav();
+
+    navToggle.addEventListener("click", () => {
+      const expanded = navToggle.getAttribute("aria-expanded") === "true";
+      expanded ? closeNav() : openNav();
+    });
+
+    navMenu.querySelectorAll("a").forEach(link => {
+      link.addEventListener("click", closeNav);
+    });
+
+    const handleQueryChange = () => {
+      closeNav();
+    };
+
+    if (typeof mobileQuery.addEventListener === "function") {
+      mobileQuery.addEventListener("change", handleQueryChange);
+    } else if (typeof mobileQuery.addListener === "function") {
+      mobileQuery.addListener(handleQueryChange);
+    }
+
+    document.addEventListener("click", event => {
+      if (!navMenu.classList.contains("is-open")) return;
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (navMenu.contains(target)) return;
+      if (navToggle.contains(target)) return;
+      closeNav();
+    });
+
+    document.addEventListener("keydown", event => {
+      if (event.key === "Escape" && navMenu.classList.contains("is-open")) {
+        closeNav();
+        navToggle.focus();
+      }
+    });
+  }
+
+  /* 4. theme toggle */
+  const themeToggle = document.querySelector(".theme-toggle");
+  const storageKey  = "bridge-delay-theme";
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+
+  const getStoredTheme = () => {
+    try {
+      return localStorage.getItem(storageKey);
+    } catch (_) {
+      return null;
+    }
+  };
+
+  const storeTheme = theme => {
+    try {
+      localStorage.setItem(storageKey, theme);
+    } catch (_) {
+      /* no-op */
+    }
+  };
+
+  const updateThemeToggle = theme => {
+    if (!themeToggle) return;
+    const isLight = theme === "light";
+    themeToggle.innerHTML = `${isLight ? "🌙" : "☀️"} ${isLight ? "Dark mode" : "Light mode"}`;
+    themeToggle.setAttribute("aria-pressed", String(isLight));
+  };
+
+  const applyTheme = theme => {
+    document.body.setAttribute("data-theme", theme);
+    updateThemeToggle(theme);
+  };
+
+  const storedTheme = getStoredTheme();
+  const initialTheme = storedTheme || (prefersDark.matches ? "dark" : "light");
+  applyTheme(initialTheme);
+
+  themeToggle?.addEventListener("click", () => {
+    const current = document.body.getAttribute("data-theme") || initialTheme;
+    const next    = current === "light" ? "dark" : "light";
+    applyTheme(next);
+    storeTheme(next);
+  });
+
+  const handleSchemeChange = event => {
+    if (!getStoredTheme()) {
+      applyTheme(event.matches ? "dark" : "light");
+    }
+  };
+
+  if (typeof prefersDark.addEventListener === "function") {
+    prefersDark.addEventListener("change", handleSchemeChange);
+  } else if (typeof prefersDark.addListener === "function") {
+    prefersDark.addListener(handleSchemeChange);
+  }
 });
 
 /* ───────── DEV-only viewport toggle (original) ──────────────*/

--- a/web/style.css
+++ b/web/style.css
@@ -21,6 +21,7 @@ body {
 
   background: var(--bg);
   color: var(--fg);
+  line-height: 1.6;
 }
 
 /* 1. NAVBAR ---------------------------------------------------- */
@@ -30,13 +31,22 @@ body {
   z-index: 999;
 
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 1.5rem;
 
   padding: 1rem 2rem;
-  background: rgba(24, 27, 32, 0.8);
+  background: var(--navbar-bg);
   backdrop-filter: blur(8px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.navbar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+  z-index: -1;
 }
 
 .logo {
@@ -46,15 +56,128 @@ body {
   text-decoration: none;
 }
 
-.navbar nav a {
-  margin-left: 1.5rem;
-  color: var(--fg-muted);
-  text-decoration: none;
-  transition: color 0.2s;
+.navbar__links {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-left: auto;
 }
 
-.navbar nav a:hover {
+.navbar__links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--fg-muted);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.navbar__links a:hover,
+.navbar__links a:focus-visible {
   color: var(--fg);
+}
+
+.nav-toggle {
+  margin-left: auto;
+  display: none;
+  border: 1px solid var(--border-soft);
+  background: transparent;
+  color: var(--fg);
+  border-radius: calc(var(--radius) * 0.7);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.nav-toggle__icon {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.nav-toggle__label {
+  font-weight: 600;
+}
+
+.nav-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--border-soft);
+  background: var(--panel);
+  color: var(--fg);
+  border-radius: calc(var(--radius) * 0.7);
+  padding: 0.4rem 0.9rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+}
+
+@media (max-width: 820px) {
+  .navbar {
+    gap: 0.75rem;
+  }
+
+  .navbar__links {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    right: 2rem;
+    flex-direction: column;
+    align-items: flex-start;
+    background: var(--panel);
+    border: 1px solid var(--border-soft);
+    border-radius: calc(var(--radius) * 1.1);
+    padding: 1rem 1.25rem;
+    min-width: 220px;
+    z-index: 998;
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.32);
+    opacity: 0;
+    transform: translateY(-10px);
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    background-clip: padding-box;
+  }
+
+  body[data-theme="light"] .navbar__links {
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.18);
+  }
+
+  .navbar__links.is-open {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .navbar__links a,
+  .navbar__links .theme-toggle {
+    width: 100%;
+    justify-content: flex-start;
+    padding: 0.35rem 0;
+  }
+
+  .navbar__links a {
+    display: flex;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
 }
 
 /* 2. HERO ------------------------------------------------------ */
@@ -123,9 +246,9 @@ body {
   padding: 2.75rem;
   margin-bottom: 4.5rem;
 
-  background: #1d1f23;
+  background: var(--panel);
   border-radius: calc(var(--radius) * 1.6);
-  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.55);
+  box-shadow: var(--shadow-xl);
   overflow: visible;
 }
 
@@ -148,10 +271,10 @@ body {
   flex: 1 1 260px;
   min-width: 250px;
   padding: 1.25rem 1.75rem;
-  background: #31343d;
+  background: var(--panel-strong);
   border-radius: calc(var(--radius) * 1.2);
   transform: translateY(-6px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-md);
 }
 
 .bubbles {
@@ -183,16 +306,16 @@ body {
 }
 
 .card {
-  background: var(--bg-alt);
+  background: var(--panel);
   padding: 2rem;
   border-radius: var(--radius);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  box-shadow: var(--shadow-sm);
   transition: transform 0.15s, box-shadow 0.15s;
 }
 
 .card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--shadow-hover);
 }
 
 .card h2 { margin-top: 0; color: var(--accent); }
@@ -203,10 +326,10 @@ body {
   max-width: 650px;
   margin: 0 auto 6rem;
   text-align: center;
-  background: #1d1f23;
+  background: var(--panel);
   padding: 3rem 2rem;
   border-radius: calc(var(--radius) * 1.4);
-  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.55);
+  box-shadow: var(--shadow-lg);
 }
 
 .signup__title   { margin: 0 0 1rem; font-size: 2rem; color: var(--accent); }
@@ -226,7 +349,7 @@ body {
   padding: 0.9rem 1rem;
   border: none;
   border-radius: var(--radius);
-  background: var(--bg-alt);
+  background: var(--panel-strong);
   color: var(--fg);
 }
 
@@ -253,7 +376,7 @@ body {
   text-align: center;
   padding: 2rem 1rem 3rem;
   color: var(--fg-muted);
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid var(--border-soft);
 }
 
 /* 7. REVEAL ANIMATION ----------------------------------------- */
@@ -292,7 +415,7 @@ body {
     flex-direction: column;
     width: 100%;                 /* full row width */
     padding: 0.85rem;
-    background: #31343d;         /* desktop slate */
+    background: var(--panel-strong);         /* desktop slate */
     border-radius: calc(var(--radius) * 1.2);
     transform: none;
   }
@@ -310,7 +433,7 @@ body.force-mobile .sms-pair       { display:block;padding:1rem;row-gap:.85rem; }
 body.force-mobile .sms-copy       { margin-bottom:.85rem; }
 body.force-mobile .sms-copy p     { margin:0; }
 body.force-mobile .bubbles-wrap   { display:flex;flex-direction:column;width:100%;
-                                     padding:.85rem;background:#31343d;
+                                     padding:.85rem;background:var(--panel-strong);
                                      border-radius:calc(var(--radius)*1.2);transform:none; }
 body.force-mobile .bubble         { width:94%;max-width:94%;align-self:center; }
 /* ═════════════════════════════════════════ */


### PR DESCRIPTION
## Summary
- replace the stacked mobile navigation with a dropdown hamburger menu and supporting styles
- add a client-side light/dark theme toggle that honors system preference and remembers the user’s choice
- refresh shared color tokens and component styles to improve text contrast in both themes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cee98afe7c832387b113ae8df6e38e